### PR TITLE
Added extra NULL pointer to end of argv

### DIFF
--- a/nargv.c
+++ b/nargv.c
@@ -159,7 +159,8 @@ NARGV *nargv_parse(char *input) {
 
     }
 
-    nvp->argv = calloc(nvp->argc, sizeof(char *));
+    // +1 for extra NULL pointer required by execv() and friends
+    nvp->argv = calloc(nvp->argc + 1, sizeof(char *));
     nvp->data = calloc(nvp->data_length, 1);
 
     // SECOND PASS

--- a/nargv.c
+++ b/nargv.c
@@ -18,7 +18,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 
-char *NARGV_IFS = " \t\n";
+const char *NARGV_IFS = " \t\n";
 
 typedef struct NARGV {
     char **argv, *data, *error_message;
@@ -30,7 +30,7 @@ void nargv_free(NARGV* props) {
     free(props);
 }
 
-void nargv_ifs(char *nifs) {
+void nargv_ifs(const char *nifs) {
     if (! nifs) {
         NARGV_IFS = " \t\n";    
     } else {
@@ -39,7 +39,7 @@ void nargv_ifs(char *nifs) {
 }
 
 int nargv_field_seperator(char seperator) {
-    char *list = NARGV_IFS;
+    const char *list = NARGV_IFS;
     if (seperator) {
         while (*list) {
             if (*list++ == seperator) return 1;
@@ -49,7 +49,7 @@ int nargv_field_seperator(char seperator) {
     return 1; // null is always a field seperator
 }
 
-NARGV *nargv_parse(char *input) {
+NARGV *nargv_parse(const char *input) {
 
     NARGV *nvp = calloc(1, sizeof(NARGV));
 

--- a/nargv.h
+++ b/nargv.h
@@ -6,5 +6,5 @@ typedef struct NARGV {
 } NARGV;
 
 void nargv_free(NARGV* props);
-void nargv_ifs(char *nifs);
-NARGV *nargv_parse(char *input);
+void nargv_ifs(const char *nifs);
+NARGV *nargv_parse(const char *input);


### PR DESCRIPTION
execv() and friends require a NULL pointer at the end of any passed-in argv.
This simply adds additional zeroed-out space to the end of argv, without
increasing argc, as would be expected from the normal argc/argv.
